### PR TITLE
removed graphiql gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,8 +33,6 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails'
-  gem 'graphiql-rails'
-
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,9 +56,6 @@ GEM
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    graphiql-rails (1.8.0)
-      railties
-      sprockets-rails
     graphql (2.0.13)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
@@ -162,7 +159,6 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
   faker
-  graphiql-rails
   graphql
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,0 @@
-//= link graphiql/rails/application.css
-//= link graphiql/rails/application.js

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,5 @@
 Rails.application.routes.draw do
-  if Rails.env.development?
-    mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: "graphql#execute"
-  end 
-  
+
   post "/graphql", to: "graphql#execute"
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
removed graphiql gem to resolve (hopefully) heroku deployment issues.