### PR TITLE
Api/item image

### DIFF
--- a/app/facades/item_image_facade.rb
+++ b/app/facades/item_image_facade.rb
@@ -1,0 +1,6 @@
+class ItemImageFacade
+  def self.get_image(item)
+    image = ItemImageService.get_item_image(item)
+    ItemImage.new(image)
+  end
+end

--- a/app/poros/item_image.rb
+++ b/app/poros/item_image.rb
@@ -1,0 +1,7 @@
+class ItemImage
+  attr_reader :url
+  def initialize(item)
+    @url = item
+  end
+
+end

--- a/app/services/item_image_service.rb
+++ b/app/services/item_image_service.rb
@@ -1,0 +1,15 @@
+class ItemImageService
+
+  def self.connection
+    Faraday.new(url: "https://api.pexels.com/v1/search", headers: {'Authorization'=>ENV['PEXELS_API_KEY']})
+  end
+
+  def self.get_item_image(item)
+    response = connection.get do |p|
+      p.params[:query] = "#{item}s"
+      p.params[:per_page] = 1
+    end
+    image = JSON.parse(response.body, symbolize_names: true)[:photos][0][:src][:original]
+  end
+
+end

--- a/spec/facades/item_image_facade_spec.rb
+++ b/spec/facades/item_image_facade_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "ItemFacade" do
+  describe "happy path" do
+    it "returns a iteam image url when called with a items name", :vcr do
+      item_image = ItemImageFacade.get_image("apple")
+      expect(item_image.url).to eq("https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg")
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/ItemFacade/happy_path/returns_a_iteam_image_url_when_called_with_a_items_name.yml
+++ b/spec/fixtures/vcr_cassettes/ItemFacade/happy_path/returns_a_iteam_image_url_when_called_with_a_items_name.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.pexels.com/v1/search?per_page=1&query=apples
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - 563492ad6f917000010000013766ed931f7b4fd7bc7697331b581cb1
+      User-Agent:
+      - Faraday v2.5.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 31 Aug 2022 22:25:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '464'
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 74392e6648938e99-DEN
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - __cf_bm=K1twCT5kKLEwuASSsL652h3hr3Z8xF7ikcORVo.yFJQ-1661981369-0-AYcMhbM0oxnXMzMoCac6ct5XLq3gtlxrHcn1hjpydVnJULJYsrUcQuD6+uLEdiy14W44By9BnxeWd+i4sSgAYVs=;
+        path=/; expires=Wed, 31-Aug-22 21:59:29 GMT; domain=.pexels.com; HttpOnly;
+        Secure; SameSite=None
+      - __cf_bm=icFdY4e4DR03hxcJoiEGPFmkrVcPdPiIMd523cvv_Ho-1661984717-0-AWCFAZndzErJfFtlcxzpTM4jn9mLT3jaZ5K4BZYroP865gdqduv91u4fbR7MJVLdjs6rXcs4KbHy28hGC1bhqog=;
+        path=/; expires=Wed, 31-Aug-22 22:55:17 GMT; domain=.pexels.com; HttpOnly;
+        Secure; SameSite=None
+      Vary:
+      - Origin, Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ratelimit-Limit:
+      - '20000'
+      X-Ratelimit-Remaining:
+      - '19966'
+      X-Ratelimit-Reset:
+      - '1664499674'
+      X-Request-Id:
+      - 8c2064fa-866b-4837-93f6-7b000b4e2663
+      X-Runtime:
+      - '0.101910'
+      X-Server:
+      - anteater
+      X-Tyk-Cached-Response:
+      - '1'
+      Server:
+      - cloudflare
+    body:
+      encoding: ASCII-8BIT
+      string: '{"page":1,"per_page":1,"photos":[{"id":1453713,"width":2304,"height":3456,"url":"https://www.pexels.com/photo/photography-of-pile-of-apples-1453713/","photographer":"Maria
+        Lindsey Content Creator","photographer_url":"https://www.pexels.com/@margemedia","photographer_id":647565,"avg_color":"#B94744","src":{"original":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg","large2x":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026dpr=2\u0026h=650\u0026w=940","large":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026h=650\u0026w=940","medium":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026h=350","small":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026h=130","portrait":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026fit=crop\u0026h=1200\u0026w=800","landscape":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026fit=crop\u0026h=627\u0026w=1200","tiny":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026dpr=1\u0026fit=crop\u0026h=200\u0026w=280"},"liked":false,"alt":"Photography
+        of Pile of Apples"}],"total_results":5826,"next_page":"https://api.pexels.com/v1/search/?page=2\u0026per_page=1\u0026query=apples"}'
+  recorded_at: Wed, 31 Aug 2022 22:25:17 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/ItemImage/happy_path/returns_a_item_image_as_a_plain_old_ruby_object.yml
+++ b/spec/fixtures/vcr_cassettes/ItemImage/happy_path/returns_a_item_image_as_a_plain_old_ruby_object.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.pexels.com/v1/search?per_page=1&query=apples
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - 563492ad6f917000010000013766ed931f7b4fd7bc7697331b581cb1
+      User-Agent:
+      - Faraday v2.5.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 01 Sep 2022 00:46:07 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '464'
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 7439fcb25ccf8eaa-DEN
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - __cf_bm=K1twCT5kKLEwuASSsL652h3hr3Z8xF7ikcORVo.yFJQ-1661981369-0-AYcMhbM0oxnXMzMoCac6ct5XLq3gtlxrHcn1hjpydVnJULJYsrUcQuD6+uLEdiy14W44By9BnxeWd+i4sSgAYVs=;
+        path=/; expires=Wed, 31-Aug-22 21:59:29 GMT; domain=.pexels.com; HttpOnly;
+        Secure; SameSite=None
+      - __cf_bm=l.YVIALihWlMIMe_m8dg1fPZ8zfJ5kM1CvJ4bLrt9mw-1661993167-0-AW9eL/vpxmJ1UOhwxBfHQhChHcEQSxsXyCvKa869owW6LbNFBoqCosb2dAYwKzNJ6PlEjwE2iDe9YkJPx69BrZY=;
+        path=/; expires=Thu, 01-Sep-22 01:16:07 GMT; domain=.pexels.com; HttpOnly;
+        Secure; SameSite=None
+      Vary:
+      - Origin, Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ratelimit-Limit:
+      - '20000'
+      X-Ratelimit-Remaining:
+      - '19964'
+      X-Ratelimit-Reset:
+      - '1664499674'
+      X-Request-Id:
+      - 8c2064fa-866b-4837-93f6-7b000b4e2663
+      X-Runtime:
+      - '0.101910'
+      X-Server:
+      - anteater
+      X-Tyk-Cached-Response:
+      - '1'
+      Server:
+      - cloudflare
+    body:
+      encoding: ASCII-8BIT
+      string: '{"page":1,"per_page":1,"photos":[{"id":1453713,"width":2304,"height":3456,"url":"https://www.pexels.com/photo/photography-of-pile-of-apples-1453713/","photographer":"Maria
+        Lindsey Content Creator","photographer_url":"https://www.pexels.com/@margemedia","photographer_id":647565,"avg_color":"#B94744","src":{"original":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg","large2x":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026dpr=2\u0026h=650\u0026w=940","large":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026h=650\u0026w=940","medium":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026h=350","small":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026h=130","portrait":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026fit=crop\u0026h=1200\u0026w=800","landscape":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026fit=crop\u0026h=627\u0026w=1200","tiny":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026dpr=1\u0026fit=crop\u0026h=200\u0026w=280"},"liked":false,"alt":"Photography
+        of Pile of Apples"}],"total_results":5826,"next_page":"https://api.pexels.com/v1/search/?page=2\u0026per_page=1\u0026query=apples"}'
+  recorded_at: Thu, 01 Sep 2022 00:46:07 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/Item_Image_API_Service/happy_path/gives_a_image_as_a_return_when_inputting_a_items_name.yml
+++ b/spec/fixtures/vcr_cassettes/Item_Image_API_Service/happy_path/gives_a_image_as_a_return_when_inputting_a_items_name.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.pexels.com/v1/search?per_page=1&query=apples
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - 563492ad6f917000010000013766ed931f7b4fd7bc7697331b581cb1
+      User-Agent:
+      - Faraday v2.5.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 31 Aug 2022 22:25:32 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '464'
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 74392ebfdc038ea2-DEN
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - __cf_bm=DnlLL0Fzvn3Goxwh2n2Z_ga8WNIe5N_6YclYZzIzyJc-1661984732-0-Afi6IxA5j0qezWjbL+alRLF+GaOoLNtN3Qb8Nxi5hcZ1kiQfN4qTeZmQ4JB1OIJwUZWw6exlK4KTeJX8KyGbWMg=;
+        path=/; expires=Wed, 31-Aug-22 22:55:32 GMT; domain=.pexels.com; HttpOnly;
+        Secure; SameSite=None
+      - __cf_bm=K1twCT5kKLEwuASSsL652h3hr3Z8xF7ikcORVo.yFJQ-1661981369-0-AYcMhbM0oxnXMzMoCac6ct5XLq3gtlxrHcn1hjpydVnJULJYsrUcQuD6+uLEdiy14W44By9BnxeWd+i4sSgAYVs=;
+        path=/; expires=Wed, 31-Aug-22 21:59:29 GMT; domain=.pexels.com; HttpOnly;
+        Secure; SameSite=None
+      Vary:
+      - Origin, Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ratelimit-Limit:
+      - '20000'
+      X-Ratelimit-Remaining:
+      - '19965'
+      X-Ratelimit-Reset:
+      - '1664499674'
+      X-Request-Id:
+      - 8c2064fa-866b-4837-93f6-7b000b4e2663
+      X-Runtime:
+      - '0.101910'
+      X-Server:
+      - anteater
+      X-Tyk-Cached-Response:
+      - '1'
+      Server:
+      - cloudflare
+    body:
+      encoding: ASCII-8BIT
+      string: '{"page":1,"per_page":1,"photos":[{"id":1453713,"width":2304,"height":3456,"url":"https://www.pexels.com/photo/photography-of-pile-of-apples-1453713/","photographer":"Maria
+        Lindsey Content Creator","photographer_url":"https://www.pexels.com/@margemedia","photographer_id":647565,"avg_color":"#B94744","src":{"original":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg","large2x":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026dpr=2\u0026h=650\u0026w=940","large":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026h=650\u0026w=940","medium":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026h=350","small":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026h=130","portrait":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026fit=crop\u0026h=1200\u0026w=800","landscape":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026fit=crop\u0026h=627\u0026w=1200","tiny":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026dpr=1\u0026fit=crop\u0026h=200\u0026w=280"},"liked":false,"alt":"Photography
+        of Pile of Apples"}],"total_results":5826,"next_page":"https://api.pexels.com/v1/search/?page=2\u0026per_page=1\u0026query=apples"}'
+  recorded_at: Wed, 31 Aug 2022 22:25:32 GMT
+recorded_with: VCR 6.1.0

--- a/spec/poros/item_image_spec.rb
+++ b/spec/poros/item_image_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe "ItemImage" do
+  describe "happy path" do
+    it "returns a item image as a plain old ruby object", :vcr do
+      image = ItemImageService.get_item_image("apple")
+      item_image = ItemImage.new(image)
+      expect(item_image).to be_a ItemImage
+      expect(item_image.url).to eq("https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg")
+    end
+  end
+end

--- a/spec/services/item_image_service_spec.rb
+++ b/spec/services/item_image_service_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Item Image API Service" do
+  describe "happy path" do
+    it "gives a image as a return when inputting a items name", :vcr do
+      item_image = ItemImageService.get_item_image("apple")
+      expect(item_image).to eq("https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg")
+    end
+  end
+end


### PR DESCRIPTION
## Why?
     - This pull request contains the ability for us to call ItemImageService.get_item_image(item) within our Ruby method for GraphQL. All tests have been made using WebMock and VCR. Can Include further sad path testing, but believe that without a name then a Item will not be created for a user. We will clarify in our stand up tomorrow.

### All Submissions:
* [X] Have you followed the guidelines in our MVP document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:
1. [X] Does your submission pass all tests?
2. [X] Have you formatted your code locally before submission?
3. [X] Have you removed any bindings/save and open page methods within test's?

### Changes to Core Features:
* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your core changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

### Other Issues/Challenges:
- [ Sad Path Testing ] 
