### PR TITLE
Add image api consumption to image creation

### DIFF
--- a/app/graphql/mutations/create_item.rb
+++ b/app/graphql/mutations/create_item.rb
@@ -10,7 +10,8 @@ class Mutations::CreateItem < Mutations::BaseMutation
   field :errors, [String], null: false 
 
   def resolve(name:, user_id:, location:, expiration_date:)
-    item = Item.new(name: name, user_id: user_id, location: location, expiration_date: expiration_date, image: "fakeimage")
+    item_image = ItemImageFacade.get_image(name)
+    item = Item.new(name: name, user_id: user_id, location: location, expiration_date: expiration_date, image: item_image.url)
 
     if item.save 
       {

--- a/spec/fixtures/vcr_cassettes/Create_Item/creates_an_item_and_returns_its_information.yml
+++ b/spec/fixtures/vcr_cassettes/Create_Item/creates_an_item_and_returns_its_information.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.pexels.com/v1/search?per_page=1&query=apples
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization:
+      - 563492ad6f917000010000018490fb2ba77c417c8345961478bc81ce
+      User-Agent:
+      - Faraday v2.5.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 05 Sep 2022 19:43:24 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '464'
+      Connection:
+      - keep-alive
+      Cf-Ray:
+      - 74617421b9ace738-EWR
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Set-Cookie:
+      - __cf_bm=HUHshk2jEmNnOxXjtC2wtUtlB496trydaKuI2gnbpZA-1662407004-0-Aam/EKIiqtzkvciYKP0U6mHyTc9CKxorIdw74UmpbBAMnTx1JDx06Wb2kEtPeriqbEFFDHHE3bFvDr78YprUFWU=;
+        path=/; expires=Mon, 05-Sep-22 20:13:24 GMT; domain=.pexels.com; HttpOnly;
+        Secure; SameSite=None
+      - __cf_bm=Ho7csAsAUOFXzHz1SqWZ9jayaRTHzRYm42PWdDAsb64-1662407004-0-AVn7JQqwkpHtMi/q2WJHzge8rlpve9hCmGq6pq08mz0cxXMyFJ2R1Ey4MFHd6GDDzfXGm1u1e3n4oHQg3zZ5hBU=;
+        path=/; expires=Mon, 05-Sep-22 20:13:24 GMT; domain=.pexels.com; HttpOnly;
+        Secure; SameSite=None
+      Vary:
+      - Origin, Accept-Encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Alt-Svc:
+      - h3=":443"; ma=86400, h3-29=":443"; ma=86400
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Ratelimit-Limit:
+      - '20000'
+      X-Ratelimit-Remaining:
+      - '19995'
+      X-Ratelimit-Reset:
+      - '1664684286'
+      X-Request-Id:
+      - 3943b180-8222-4013-b9ae-275dac072473
+      X-Runtime:
+      - '0.114956'
+      X-Server:
+      - alpaca
+      Server:
+      - cloudflare
+    body:
+      encoding: ASCII-8BIT
+      string: '{"page":1,"per_page":1,"photos":[{"id":1453713,"width":2304,"height":3456,"url":"https://www.pexels.com/photo/photography-of-pile-of-apples-1453713/","photographer":"Maria
+        Lindsey Content Creator","photographer_url":"https://www.pexels.com/@margemedia","photographer_id":647565,"avg_color":"#B94744","src":{"original":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg","large2x":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026dpr=2\u0026h=650\u0026w=940","large":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026h=650\u0026w=940","medium":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026h=350","small":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026h=130","portrait":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026fit=crop\u0026h=1200\u0026w=800","landscape":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026fit=crop\u0026h=627\u0026w=1200","tiny":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026dpr=1\u0026fit=crop\u0026h=200\u0026w=280"},"liked":false,"alt":"Photography
+        of Pile of Apples"}],"total_results":5802,"next_page":"https://api.pexels.com/v1/search/?page=2\u0026per_page=1\u0026query=apples"}'
+  recorded_at: Mon, 05 Sep 2022 19:43:24 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/Create_Item/creates_an_item_and_returns_its_information.yml
+++ b/spec/fixtures/vcr_cassettes/Create_Item/creates_an_item_and_returns_its_information.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.pexels.com/v1/search?per_page=1&query=apples
+    uri: https://api.pexels.com/v1/search?per_page=1&query=Spinachs
     body:
       encoding: US-ASCII
       string: ''
@@ -21,23 +21,23 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 05 Sep 2022 19:43:24 GMT
+      - Mon, 05 Sep 2022 19:56:01 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
-      - '464'
+      - '474'
       Connection:
       - keep-alive
       Cf-Ray:
-      - 74617421b9ace738-EWR
+      - 7461869b89658cdc-EWR
       Cache-Control:
       - max-age=0, private, must-revalidate
       Set-Cookie:
-      - __cf_bm=HUHshk2jEmNnOxXjtC2wtUtlB496trydaKuI2gnbpZA-1662407004-0-Aam/EKIiqtzkvciYKP0U6mHyTc9CKxorIdw74UmpbBAMnTx1JDx06Wb2kEtPeriqbEFFDHHE3bFvDr78YprUFWU=;
-        path=/; expires=Mon, 05-Sep-22 20:13:24 GMT; domain=.pexels.com; HttpOnly;
+      - __cf_bm=4WZnXcrDcS9A.rsrdxx6eRf9vR6lxVzXCAwgSrfAXkI-1662406888-0-Aaxe3waTKyFafSPDIlPnWl8H/W3j0giZcfkW9HvUx1CqJ6thzpDgWsOG8kVI79cpc1m/U/QwMUjjYulKx65Icg4=;
+        path=/; expires=Mon, 05-Sep-22 20:11:28 GMT; domain=.pexels.com; HttpOnly;
         Secure; SameSite=None
-      - __cf_bm=Ho7csAsAUOFXzHz1SqWZ9jayaRTHzRYm42PWdDAsb64-1662407004-0-AVn7JQqwkpHtMi/q2WJHzge8rlpve9hCmGq6pq08mz0cxXMyFJ2R1Ey4MFHd6GDDzfXGm1u1e3n4oHQg3zZ5hBU=;
-        path=/; expires=Mon, 05-Sep-22 20:13:24 GMT; domain=.pexels.com; HttpOnly;
+      - __cf_bm=qBNQ8lYEFj_xw4qL1Wvu5F2.ZPtcn9mRoAzYSYBcDBI-1662407761-0-AZpZSo9YpeJRKImm6mCtpETZ9Aeo4Z/f6vEWuQRsivR5o30XXdcHRpPc6LoU86kI4Z40EL9datLMf3CfO1Q0z70=;
+        path=/; expires=Mon, 05-Sep-22 20:26:01 GMT; domain=.pexels.com; HttpOnly;
         Secure; SameSite=None
       Vary:
       - Origin, Accept-Encoding
@@ -50,21 +50,23 @@ http_interactions:
       X-Ratelimit-Limit:
       - '20000'
       X-Ratelimit-Remaining:
-      - '19995'
+      - '19990'
       X-Ratelimit-Reset:
       - '1664684286'
       X-Request-Id:
-      - 3943b180-8222-4013-b9ae-275dac072473
+      - 52fbb0ae-4d99-410c-9a63-9f1f9b336ec1
       X-Runtime:
-      - '0.114956'
+      - '0.199030'
       X-Server:
-      - alpaca
+      - anteater
+      X-Tyk-Cached-Response:
+      - '1'
       Server:
       - cloudflare
     body:
       encoding: ASCII-8BIT
-      string: '{"page":1,"per_page":1,"photos":[{"id":1453713,"width":2304,"height":3456,"url":"https://www.pexels.com/photo/photography-of-pile-of-apples-1453713/","photographer":"Maria
-        Lindsey Content Creator","photographer_url":"https://www.pexels.com/@margemedia","photographer_id":647565,"avg_color":"#B94744","src":{"original":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg","large2x":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026dpr=2\u0026h=650\u0026w=940","large":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026h=650\u0026w=940","medium":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026h=350","small":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026h=130","portrait":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026fit=crop\u0026h=1200\u0026w=800","landscape":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026fit=crop\u0026h=627\u0026w=1200","tiny":"https://images.pexels.com/photos/1453713/pexels-photo-1453713.jpeg?auto=compress\u0026cs=tinysrgb\u0026dpr=1\u0026fit=crop\u0026h=200\u0026w=280"},"liked":false,"alt":"Photography
-        of Pile of Apples"}],"total_results":5802,"next_page":"https://api.pexels.com/v1/search/?page=2\u0026per_page=1\u0026query=apples"}'
-  recorded_at: Mon, 05 Sep 2022 19:43:24 GMT
+      string: '{"page":1,"per_page":1,"photos":[{"id":6947254,"width":3709,"height":5564,"url":"https://www.pexels.com/photo/photo-of-pancakes-with-ingredients-6947254/","photographer":"Vlada
+        Karpovich","photographer_url":"https://www.pexels.com/@vlada-karpovich","photographer_id":2278756,"avg_color":"#907962","src":{"original":"https://images.pexels.com/photos/6947254/pexels-photo-6947254.jpeg","large2x":"https://images.pexels.com/photos/6947254/pexels-photo-6947254.jpeg?auto=compress\u0026cs=tinysrgb\u0026dpr=2\u0026h=650\u0026w=940","large":"https://images.pexels.com/photos/6947254/pexels-photo-6947254.jpeg?auto=compress\u0026cs=tinysrgb\u0026h=650\u0026w=940","medium":"https://images.pexels.com/photos/6947254/pexels-photo-6947254.jpeg?auto=compress\u0026cs=tinysrgb\u0026h=350","small":"https://images.pexels.com/photos/6947254/pexels-photo-6947254.jpeg?auto=compress\u0026cs=tinysrgb\u0026h=130","portrait":"https://images.pexels.com/photos/6947254/pexels-photo-6947254.jpeg?auto=compress\u0026cs=tinysrgb\u0026fit=crop\u0026h=1200\u0026w=800","landscape":"https://images.pexels.com/photos/6947254/pexels-photo-6947254.jpeg?auto=compress\u0026cs=tinysrgb\u0026fit=crop\u0026h=627\u0026w=1200","tiny":"https://images.pexels.com/photos/6947254/pexels-photo-6947254.jpeg?auto=compress\u0026cs=tinysrgb\u0026dpr=1\u0026fit=crop\u0026h=200\u0026w=280"},"liked":false,"alt":"Cookies
+        on White Ceramic Plate"}],"total_results":387,"next_page":"https://api.pexels.com/v1/search/?page=2\u0026per_page=1\u0026query=Spinachs"}'
+  recorded_at: Mon, 05 Sep 2022 19:56:01 GMT
 recorded_with: VCR 6.1.0

--- a/spec/graphql/mutations/create_item_spec.rb
+++ b/spec/graphql/mutations/create_item_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Create Item' do
-  it "creates an item and returns its information" do
+  it "creates an item and returns its information", :vcr do
     user1 = User.create!(name: "Harry Potter", email: "hpotter@hogwarts.edu")
 
     query = <<~GQL
@@ -34,7 +34,7 @@ RSpec.describe 'Create Item' do
     expect(item["location"]).to eq("fridge")
     expect(item["expirationDate"]).to eq("2001-02-03T04:05:06Z")
     expect(item["userId"]).to be_an Integer
-    expect(item["image"]).to eq("fakeimage")
+    expect(item["image"]).to be_a String
     expect(item["forDonation"]).to eq(false)
 
   end  


### PR DESCRIPTION
Updated image attribute on item create to hit the Pexels image api and return an image of the given item, rather than a hard coded image url. 