### PR TITLE
Add production link to cors configuration

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'http://localhost:3000' #, 'https://waste-not-fe.herokuapp.com'
+    origins 'http://localhost:3000', 'https://waste-not-wn.herokuapp.com'
 
     resource '*',
       headers: :any,


### PR DESCRIPTION
Add production link to cors config now that the FE has been pushed to Heroku. 